### PR TITLE
実行用シェルスクリプト追加＆vacuum処理修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ post_log.sqlite
 .lock
 lib
 __pycache__
+*.log
+*.sqlite
+bsky_session.json
+run_counter.txt

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+
+# カウンタのファイルを設定
+COUNTER_FILE="run_counter.txt"
+
+# 初回実行時にカウンタファイルがない場合は初期化
+if [ ! -f "$COUNTER_FILE" ]; then
+    echo 0 > "$COUNTER_FILE"
+fi
+
+# カウンタ値を取得
+COUNTER=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+
+# プログラムの実行
+if (( COUNTER % 2 == 9000 )); then
+    # vacuumオプション（旧データ削除）付きのコマンド
+    python3 feedreader.py --vacuum
+    # カウンタをリセット
+    COUNTER=0
+else
+    # 通常コマンド
+    python3 feedreader.py
+fi
+
+# カウンタ値をインクリメントして保存
+((COUNTER++))
+echo "$COUNTER" > "$COUNTER_FILE"


### PR DESCRIPTION
- サーバ上に配置していた実行用シェルスクリプトをバージョン管理に追加
- vacuum周りのバグを修正
- gitignoreの設定追加

vacuum周りの修正によりcreated_atの書式が変わっています。
これ以前のsqliteファイルは使えないので注意。
（正確には使えるものの、既に格納済みレコードに対してvacuumが正常に動かないまま）